### PR TITLE
test: parameterize tests via env variables

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,22 @@
+TEST	      						= $(patsubst %.js, run-%.js, $(wildcard test/*.js))
+BROWSER								 ?= chrome chromium electron firefox
+
+test: $(addprefix test-, $(BROWSER))
+
+test-chrome:
+	@make -k TEST_BROWSER=chrome run-test
+
+test-chromium:
+	@make -k TEST_BROWSER=chromium run-test
+
+test-electron:
+	@make -k TEST_BROWSER=electron run-test
+
+test-firefox:
+	@make -k TEST_BROWSER=firefox run-test
+
+run-test: $(TEST)
+run-test/%.js: test/%.js
+	@node $<
+
+.PHONY: test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cross platform browser process creation",
   "main": "lib/browser_process.js",
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "make test"
   },
   "author": "Casper Beyer <caspervonb@qup.io>",
   "license": "MIT",

--- a/test/find.js
+++ b/test/find.js
@@ -4,20 +4,13 @@ const browser = require('..');
 const test = require('tape');
 const path = require('path');
 
-const names = [
-  'chrome',
-  'chromium',
-  'electron',
-  'firefox',
-];
+const name = (process.env['TEST_BROWSER'] || 'chrome');
 
-names.forEach(function (name) {
-  test('find ' + name, function (assert) {
-    assert.plan(2);
+test(`find ${name}`, assert => {
+  assert.plan(2);
 
-    browser.find(name, function (error, command) {
-      assert.error(error);
-      assert.ok(path.isAbsolute(command));
-    });
+  browser.find(name, (error, command) => {
+    assert.error(error);
+    assert.ok(path.isAbsolute(command));
   });
 });

--- a/test/options.js
+++ b/test/options.js
@@ -4,26 +4,46 @@ const browser = require('..');
 const test = require('tape');
 
 const name = (process.env['TEST_BROWSER'] || 'chrome');
+const type = browser.type(name);
 
-const options = {
-  chrome: {
+test(`chrome options`, { skip: !type.match(/chrome/) }, assert => {
+  const options = {
     debug: { value: 4000, expect: ['--remote-debugging-port=4000'] },
     private: { value: true, expect: ['--incognito'] },
     url: { value: 'about:blank', expect: ['about:blank'] },
     window: { value: true, expect: ['--new-window'] },
-  },
+  };
 
-  firefox: {
+  const keys = Object.keys(options);
+
+  assert.plan(keys.length * 3);
+
+  keys.forEach(key => {
+    let option = options[key];
+
+    assert.deepEqual(browser.options(name, {
+      [key]: option.value,
+    }), option.expect);
+
+    browser.find(name, (error, command) => {
+      assert.error(error);
+      assert.deepEqual(browser.options(command, {
+        [key]: option.value,
+      }), option.expect);
+    });
+  });
+});
+
+test(`firefox options`, { skip: !type.match(/firefox/) }, assert => {
+  const options = {
     debug: { value: 4000, expect: ['--start-debugging-server', '4000'] },
     private: { value: true, expect: ['--private'] },
     url: { value: 'about:blank', expect: ['about:blank'] },
     window: { value: true, expect: ['--new-window'] },
-  },
-}[browser.type(name)];
+  };
 
-const keys = Object.keys(options);
+  const keys = Object.keys(options);
 
-test(`options for ${name}`, assert => {
   assert.plan(keys.length * 3);
 
   keys.forEach(key => {

--- a/test/options.js
+++ b/test/options.js
@@ -3,53 +3,41 @@
 const browser = require('..');
 const test = require('tape');
 
-const types = {
-  'chrome': [
-    '--incognito',
-    '--new-window',
-    '--user-data-dir=profile_dir',
-    '--remote-debugging-port=4000',
-    'about:blank'
-  ],
+const name = (process.env['TEST_BROWSER'] || 'chrome');
 
-  'firefox': [
-    '--private',
-    '--new-window',
-    '--profile', 'profile_dir',
-    '--start-debugging-server', '4000',
-    'about:blank'
-  ],
-};
+const options = {
+  chrome: {
+    debug: { value: 4000, expect: ['--remote-debugging-port=4000'] },
+    private: { value: true, expect: ['--incognito'] },
+    url: { value: 'about:blank', expect: ['about:blank'] },
+    window: { value: true, expect: ['--new-window'] },
+  },
 
-var names = {
-  'chrome': 'chrome',
-  'chromium': 'chrome',
-  'electron': 'chrome',
-  'firefox': 'firefox',
-};
+  firefox: {
+    debug: { value: 4000, expect: ['--start-debugging-server', '4000'] },
+    private: { value: true, expect: ['--private'] },
+    url: { value: 'about:blank', expect: ['about:blank'] },
+    window: { value: true, expect: ['--new-window'] },
+  },
+}[browser.type(name)];
 
-Object.keys(names).forEach(name => {
-  let type = names[name];
+const keys = Object.keys(options);
 
-  test(name + ' options', assert => {
-    assert.plan(3);
+test(`options for ${name}`, assert => {
+  assert.plan(keys.length * 3);
 
-    let options = {
-      private: true,
-      window: true,
-      profile: 'profile_dir',
-      debug: 4000,
-      url: 'about:blank',
-    };
+  keys.forEach(key => {
+    let option = options[key];
 
-    let args = browser.options(name, options);
-    assert.deepEqual(args, types[type]);
+    assert.deepEqual(browser.options(name, {
+      [key]: option.value,
+    }), option.expect);
 
     browser.find(name, (error, command) => {
       assert.error(error);
-
-      let args = browser.options(command, options);
-      assert.deepEqual(args, types[type]);
+      assert.deepEqual(browser.options(command, {
+        [key]: option.value,
+      }), option.expect);
     });
   });
 });

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -2,23 +2,50 @@
 
 const browser = require('..');
 const test = require('tape');
-const path = require('path');
+const http = require('http');
 
 const name = (process.env['TEST_BROWSER'] || 'chrome');
 
-test(`spawn ${name}`, assert => {
+test(`spawn ${name}`, { skip: name.match(/electron/) }, assert => {
   assert.plan(3);
 
-  browser.spawn(name, (error, ps) => {
+  let server = http.createServer();
+  server.once('listening', () => {
+    let address = server.address();
+    browser.spawn(name, [`http://localhost:${address.port}`], (error, ps) => {
+      assert.error(error);
+      assert.ok(ps);
+
+      server.once('request', () => {
+        ps.once('close', () => {
+          server.once('close', () => {
+            assert.pass('close');
+          });
+
+          server.close();
+        });
+
+        ps.kill();
+      });
+    });
+  });
+
+  server.listen();
+});
+
+test(`spawn electron`, { skip: name.match(/electron/) }, assert => {
+  assert.plan(3);
+
+  browser.spawn(name, ['--version'], (error, ps) => {
     assert.error(error);
     assert.ok(ps);
 
-    setTimeout(() => {
-      ps.once('close', (code) => {
+    ps.stdout.once('data', () => {
+      ps.once('close', () => {
         assert.pass('close');
       });
 
       ps.kill();
-    }, 1000);
+    });
   });
 });

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -4,26 +4,21 @@ const browser = require('..');
 const test = require('tape');
 const path = require('path');
 
-const names = [
-  'chrome',
-  'chromium',
-  'electron',
-  'firefox',
-];
+const name = (process.env['TEST_BROWSER'] || 'chrome');
 
-names.forEach(name => {
-  test('spawn ' + name, assert => {
-    assert.plan(2);
+test(`spawn ${name}`, assert => {
+  assert.plan(3);
 
-    browser.spawn(name, (error, ps) => {
-      assert.on('end', () => {
-        if (ps) {
-          ps.kill();
-        }
+  browser.spawn(name, (error, ps) => {
+    assert.error(error);
+    assert.ok(ps);
+
+    setTimeout(() => {
+      ps.once('close', (code) => {
+        assert.pass('close');
       });
 
-      assert.error(error);
-      assert.ok(ps);
-    });
+      ps.kill();
+    }, 1000);
   });
 });

--- a/test/type.js
+++ b/test/type.js
@@ -2,21 +2,23 @@
 
 const browser = require('..');
 const test = require('tape');
+const path = require('path');
 
-const names = {
+const name = (process.env['TEST_BROWSER'] || 'chrome');
+
+const type = {
   'chrome': 'chrome',
   'chromium': 'chrome',
   'electron': 'chrome',
   'firefox': 'firefox',
-};
+}[name];
 
-Object.keys(names).forEach(name => {
-  test('type of ' + name, assert => {
-    assert.plan(2);
+test(`type of ${name}`, (assert) => {
+  assert.plan(3);
 
-    browser.find(name, (error, command) => {
-      assert.error(error);
-      assert.equal(browser.type(command), names[name]);
-    });
+  assert.equal(browser.type(name), type);
+  browser.find(name, (error, command) => {
+    assert.error(error);
+    assert.equal(browser.type(command), type);
   });
 });


### PR DESCRIPTION
There's a lot of looping going on in the tests, which makes them very
tedious to maintain, there's no ability to control which browsers to
expect on a given test platform.

This removes all the iteration over different browsers, instead we use
an environment variable to control which browser is being tested and set
up our test matrix via a makefile. Doing this via make also allows make
to be called with multi-threading (e.g `make -j`).