### PR TITLE
lib: resolve paths with fs.realpath

### DIFF
--- a/lib/browser_process.js
+++ b/lib/browser_process.js
@@ -166,25 +166,24 @@ function type(identifier) {
     return types[identifier];
   }
 
-  let basename = path.basename(identifier);
   let name = Object.keys(paths).find(name => {
-    return paths[name].some(exename => {
-      return basename === path.basename(exename);
+    return paths[name].some(command => {
+      return path.basename(identifier) === path.basename(command);
     });
   });
 
-  if (name) {
-    return types[name];
+  if (!name) {
+    throw new TypeError(`Invalid browser identifier \`${identifier}\``);
   }
 
-  throw new TypeError(`Invalid browser identifier \`${identifier}\``);
+  return types[name];
 }
 
 module.exports.type = type;
 
 function find(identifier, callback) {
   if (path.isAbsolute(identifier)) {
-    return callback(null, identifier);
+    return fs.realpath(identifier, callback);
   }
 
   if (!paths[identifier]) {
@@ -196,8 +195,8 @@ function find(identifier, callback) {
   let pending = paths[identifier].length;
 
   paths[identifier].forEach((command, index) => {
-    fs.stat(command, (error, stat) => {
-      if (stat) {
+    fs.realpath(command, (error, command) => {
+      if (command) {
         commands.push({
           index,
           command,
@@ -225,16 +224,19 @@ module.exports.find = find;
 
 function findSync(identifier) {
   if (path.isAbsolute(identifier)) {
-    return identifier;
+    return fs.realpathSync(identifier);
   }
 
   if (!paths[identifier]) {
     throw new TypeError(`Invalid browser identifier \`${identifier}\``);
   }
 
-  let done = false;
-  return paths[identifier].find(filename => {
-    return fs.existsSync(filename);
+  return paths[identifier].map(command => {
+    try {
+      return fs.realpathSync(command);
+    } catch (error) { }
+  }).find(command => {
+    return command;
   });
 }
 
@@ -246,10 +248,10 @@ function detect(callback) {
   let pending = 0;
   Object.keys(paths).forEach(name => {
     pending += paths[name].length;
-    paths[name].forEach(filename => {
-      fs.stat(filename, (error, stat) => {
-        if (stat) {
-          commands.push(filename);
+    paths[name].forEach(command => {
+      fs.realpath(command, (error, command) => {
+        if (command) {
+          commands.push(command);
         }
 
         if (--pending == 0) {
@@ -267,12 +269,11 @@ module.exports.detect = detect;
 function detectSync() {
   let commands = [];
 
-  let pending = 0;
   Object.keys(paths).forEach(name => {
-    paths[name].forEach(filename => {
-      if (fs.existsSync(filename)) {
-        commands.push(filename);
-      }
+    paths[name].forEach(command => {
+      try {
+        commands.push(fs.realpathSync(command));
+      } catch (error) { }
     });
   });
 
@@ -367,19 +368,13 @@ function spawn(name, args, options, callback) {
       return callback(error);
     }
 
-    fs.realpath(command, (error, command) => {
-      if (error) {
-        return callback(error);
-      }
+    debug('spawn %s %s', command, util.inspect(args));
+    let ps = child.spawn(command, args, options);
+    ps.once('error', callback);
 
-      debug('spawn %s %s', command, util.inspect(args));
-      let ps = child.spawn(command, args, options);
-      ps.once('error', callback);
-
-      process.nextTick(function () {
-        ps.removeListener('error', callback);
-        callback(null, ps);
-      });
+    process.nextTick(function () {
+      ps.removeListener('error', callback);
+      callback(null, ps);
     });
   });
 }


### PR DESCRIPTION
Spawn resolves executable paths with fs.realpath, this is somewhat
non-trivial to explain and document. Its much more natural if the search
functions return a resolved real path.

This makes the search functions resolve the resulting command paths with
fs.realpath.

This closes issue #21.
