### PR TITLE
lib: make find deterministic

### DIFF
--- a/lib/browser_process.js
+++ b/lib/browser_process.js
@@ -192,15 +192,31 @@ function find(identifier, callback) {
     return callback(error);
   }
 
-  let done = false;
-  paths[identifier].forEach(filename => {
-    fs.stat(filename, (error, stat) => {
-      if (error || done) {
-        return;
+  let commands = [];
+  let pending = paths[identifier].length;
+
+  paths[identifier].forEach((command, index) => {
+    fs.stat(command, (error, stat) => {
+      if (stat) {
+        commands.push({
+          index,
+          command,
+        });
       }
 
-      done = true;
-      callback(null, filename);
+      if (--pending == 0) {
+        if (commands.length == 0) {
+          return callback(new Error(`Unable to find browser \`${identifier}\``));
+        }
+
+        return callback(null, commands.sort((a, b) => {
+          return a.index - b.index;
+        }).map(pair => {
+          return pair.command;
+        }).find(command => {
+          return command;
+        }));
+      }
     });
   });
 }


### PR DESCRIPTION
Currently `find` will return the first match it finds, which means its
basically a race condition and won't always return the same result. This
is not what we want, we need it to always return the first match in the
order the paths are listed.

This makes it deterministic by checking all the paths, and returning
the first match sorted by index.