### PR TITLE
doc: fix formatting of parameter lists

### DIFF
--- a/doc/man/browser_process.3.md
+++ b/doc/man/browser_process.3.md
@@ -2,26 +2,26 @@
 
 ## METHODS
 
-[`browser_process.detect`](browser_process.detect.3.md)
-:   Detect available browser executables.
+* [`browser_process.detect`](browser_process.detect.3.md):  
+    Detect available browser executables.
 
-[`browser_process.detectSync`](browser_process.detectSync.3.md)
-:   Detect available browser executables synchronously.
+* [`browser_process.detectSync`](browser_process.detectSync.3.md):  
+    Detect available browser executables synchronously.
 
-[`browser_process.find`](browser_process.find.3.md)
-:   Search for a browser executable.
+* [`browser_process.find`](browser_process.find.3.md):  
+    Search for a browser executable.
 
-[`browser_process.findSync`](browser_process.findSync.3.md)
-:   Search for a browser executable synchronously.
+* [`browser_process.findSync`](browser_process.findSync.3.md):  
+    Search for a browser executable synchronously.
 
-[`browser_process.options`](browser_process.find.3.md)
-:   Generate browser command line arguments
+* [`browser_process.options`](browser_process.find.3.md):  
+    Generate browser command line arguments
 
-[`browser_process.spawn`](browser_process.spawn.3.md)
-:   Launch a new browser process
+* [`browser_process.spawn`](browser_process.spawn.3.md):  
+    Launch a new browser process
 
-[`browser_process.type`](browser_process.find.3.md)
-:   Get the type of a browser identifier
+* [`browser_process.type`](browser_process.find.3.md):  
+    Get the type of a browser identifier
 
 ## DESCRIPTION
 

--- a/doc/man/browser_process.detect.3.md
+++ b/doc/man/browser_process.detect.3.md
@@ -8,8 +8,8 @@ detect(callback)
 
 ## PARAMETERS
 
-`callback` *Function*
-:   The callback to use.
+* `callback` *Function*:  
+    The callback to use.
 
 ## DESCRIPTION
 

--- a/doc/man/browser_process.find.3.md
+++ b/doc/man/browser_process.find.3.md
@@ -8,11 +8,11 @@ find(name, callback)
 
 ## PARAMETERS
 
-`name` *String*
-:   The name to use.
+* `name` *String*:  
+    The name to use.
 
-`callback` *Function*
-:   The callback to use.
+* `callback` *Function*:  
+    The callback to use.
 
 ## DESCRIPTION
 

--- a/doc/man/browser_process.findSync.3.md
+++ b/doc/man/browser_process.findSync.3.md
@@ -8,8 +8,8 @@ findSync(name)
 
 ## PARAMETERS
 
-`name` *String*
-:   The name to use.
+* `name` *String*:  
+    The name to use.
 
 ## DESCRIPTION
 

--- a/doc/man/browser_process.options.3.md
+++ b/doc/man/browser_process.options.3.md
@@ -8,20 +8,24 @@ options(identifier, values)
 
 ## PARAMETERS
 
-`identifier` *String*
-:   The browser identifier to use.
+* `identifier` *String*:  
+    The browser identifier to use.
 
-`values` *Object*
-:   `debug` *Integer*
-    :   Start with the debugger listening on the given port
-:   `private` *Boolean*
-    :   Open in private browsing mode.
-:   `profile` *Integer*
-    :   Start with the profile with the given path
-:   `url` *String*
-    :   Open URL in a new tab or window
-:   `window` *Boolean*
-    :   Open in a new window
+* `values` *Object*:  
+    * `debug` *Integer*:  
+        Start with the debugger listening on the given port
+
+    * `private` *Boolean*:  
+        Open in private browsing mode.
+
+    * `profile` *Integer*:  
+        Start with the profile with the given path
+
+    * `url` *String*:  
+        Open URL in a new tab or window
+
+    * `window` *Boolean*:  
+        Open in a new window
 
 ## DESCRIPTION
 

--- a/doc/man/browser_process.spawn.3.md
+++ b/doc/man/browser_process.spawn.3.md
@@ -8,28 +8,33 @@ spawn(identifier [, args] [, options], callback)
 
 ## PARAMETERS
 
-`identifier` *String*
-:   The identifier to use.
+* `identifier` *String*:
+    The identifier to use.
 
-`args` *Array*
-:   The command line arguments to use.
+* `args` *Array*:  
+    The command line arguments to use.
 
-`options` *Object*
-:   `cwd` *String*
-    :   Current working directory of the browser process
-:   `env` *Object*
-    :   Environment variables in key-value pairs
-:   `stdio` *Array*|*String*
-    :   Standard I/O configuration
-:   `detatched` *Boolean*
-    :   Prepare process to run independently of its parent process.
-:   `uid` *Number*
-    :   Set the user identify of the process.
-:   `gid` *Number*
-    :   Set the group identify of the process.
+* `options` *Object*:  
+    * `cwd` *String*:  
+        Current working directory of the browser process
 
-`callback` *Function*
-:   The callback to use.
+    * `env` *Object*:  
+        Environment variables in key-value pairs
+
+    * `stdio` *Array*|*String*:  
+        Standard I/O configuration
+
+    * `detatched` *Boolean*:  
+        Prepare process to run independently of its parent process.
+
+    * `uid` *Number*:  
+        Set the user identify of the process.
+
+    * `gid` *Number*:  
+        Set the group identify of the process.
+
+* `callback` *Function*:  
+    The callback to use.
 
 ## DESCRIPTION
 


### PR DESCRIPTION
GitHub flavored markdown will not render extended definition lists, so we
need to have a multi step process for this.

This converts definition lists into regular lists with breaklines, which
will render on GitHub and other GFM based renders with a reasonable
approximation to definition lists.

This closes #20 
